### PR TITLE
Bug Fixing

### DIFF
--- a/CA2_AntanasZalisauskas_PatrickNugent/CharacterSelectionState.cpp
+++ b/CA2_AntanasZalisauskas_PatrickNugent/CharacterSelectionState.cpp
@@ -76,6 +76,7 @@ CharacterSelectionState::CharacterSelectionState(StateStack& stack, Context cont
 	exit_button->SetCallback([this]()
 		{
 			RequestStackPop();
+			RequestStackPush(StateID::kMenu);
 		});
 
 	m_gui_container.Pack(scooby_button);

--- a/CA2_AntanasZalisauskas_PatrickNugent/MenuState.cpp
+++ b/CA2_AntanasZalisauskas_PatrickNugent/MenuState.cpp
@@ -29,6 +29,7 @@ MenuState::MenuState(StateStack& stack, Context context)
 	host_play_button->SetCallback([this, context]()
 	{
 		*context.modeSelection = StateID::kHostGame;
+		RequestStackPop();
 		RequestStackPush(StateID::kCharacterSelection);
 	});
 
@@ -38,6 +39,7 @@ MenuState::MenuState(StateStack& stack, Context context)
 	join_play_button->SetCallback([this, context]()
 	{
 		*context.modeSelection = StateID::kJoinGame;
+		RequestStackPop();
 		RequestStackPush(StateID::kCharacterSelection);
 	});
 

--- a/CA2_AntanasZalisauskas_PatrickNugent/World.cpp
+++ b/CA2_AntanasZalisauskas_PatrickNugent/World.cpp
@@ -490,14 +490,17 @@ void World::SpawnFlyingEnemies(sf::Int8 enemyType)
 /// </summary>
 void World::SpawnPickups(sf::Int8 pickupType, sf::Int16 pickupPosition)
 {
-	//Spawn a random pickup from the vector of pickup spawn points
-	PickupSpawnPoint spawn = m_pickup_spawn_points[pickupType];
-	std::unique_ptr<Pickup> pickup(new Pickup(spawn.m_type, spawn.m_value, m_textures));
+	if(pickupType >= 0 && pickupType < m_pickup_spawn_points.size())
+	{
+		//Spawn a random pickup from the vector of pickup spawn points
+		PickupSpawnPoint spawn = m_pickup_spawn_points[pickupType];
+		std::unique_ptr<Pickup> pickup(new Pickup(spawn.m_type, spawn.m_value, m_textures));
 
-	//Use the random x value for the pickup's position (within the bounds)
-	pickup->setPosition((float)pickupPosition, spawn.m_y);
+		//Use the random x value for the pickup's position (within the bounds)
+		pickup->setPosition((float)pickupPosition, spawn.m_y);
 
-	m_scene_layers[static_cast<int>(Layers::kAir)]->AttachChild(std::move(pickup));
+		m_scene_layers[static_cast<int>(Layers::kAir)]->AttachChild(std::move(pickup));
+	}
 }
 
 void World::AddEnemy(CharacterType type, bool isFlying, float relX, float relY)


### PR DESCRIPTION
-Fixed in game issue caused by the character select not being popped once game starts
-Fixed a crash related to pickups where once game ends, an if check was added to SpawnPickups which checks if the random number is between 0 and the pickup spawn points array size